### PR TITLE
ignore repos folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.zwc
+repos


### PR DESCRIPTION
This helps keep things clean when we use zcomet as a git submodule,
because populating the "repos" folder does not result in git thinking that
the zcomet repo itself has become dirty.