### PR TITLE
use --depth=1 for git clone and git submodule update

### DIFF
--- a/zcomet.zsh
+++ b/zcomet.zsh
@@ -318,7 +318,7 @@ _zcomet_clone_repo() {
   [[ -d $repo_dir ]] && return
 
   print -P "%B%F{yellow}Cloning ${repo}:%f%b"
-  if ! command git clone "https://${ZCOMET[GITSERVER]}/${repo}" "$repo_dir"; then
+  if ! command git clone "https://${ZCOMET[GITSERVER]}/${repo}" --depth=1 "$repo_dir"; then
     ret=$?
     >&2 print "Could not clone repository ${repo}."
     return $ret
@@ -332,7 +332,7 @@ _zcomet_clone_repo() {
   if (( submodules )) && [[ -e ${repo_dir}/.gitmodules ]]; then
     (
       if ! cd $repo_dir ||
-         ! git submodule update --init --recursive; then
+         ! git submodule update --init --recursive --depth=1; then
         ret=$?
         >&2 print 'Could not initialize and update submodule(s).'
         return $ret


### PR DESCRIPTION
hi. i think there's no need to pull entire git plugin history as zcomet does not have any use of that (or did i miss something?). i got hit by this while migrating from another plugin manager (i like zcomet's simplicity :slightly_smiling_face:), pretty annoying yet simple to fix.

so i simply add `--depth=1` opt for git here. it saves a lot on time and disk space for loading repos with large history

eg in my setup:
```sh
in ~/.zcomet
❯  rm -rf repos && exec zsh # current default
Cloning sorin-ionescu/prezto: ...
Cloning agkozak/zsh-z: ...
Cloning romkatv/zsh-prompt-benchmark: ...

in ~/.zcomet
❯  du -hs repos
104M    repos
```
with the fix
```sh
in ~/.zcomet
❯  rm -rf repos && exec zsh # with depth=1
Cloning sorin-ionescu/prezto: ...
Cloning agkozak/zsh-z: ...
Cloning romkatv/zsh-prompt-benchmark: ...

in ~/.zcomet
❯  du -hs repos
20M     repos
```

you could say that prezto on its own is not so representative but here's example of widely (i hope so :slightly_smiling_face:) used romkatv/powerlevel10k
```sh
in /tmp
❯  git clone https://github.com/romkatv/powerlevel10k p10k
Cloning into 'p10k'...
remote: Enumerating objects: 16800, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (36/36), done.
remote: Total 16800 (delta 44), reused 25 (delta 25), pack-reused 16739 (from 4)
Receiving objects: 100% (16800/16800), 70.45 MiB | 10.55 MiB/s, done.
Resolving deltas: 100% (10966/10966), done.
# took ~10s

in /tmp
❯  git clone https://github.com/romkatv/powerlevel10k --depth=1 p10k-d1
Cloning into 'p10k-d1'...
remote: Enumerating objects: 92, done.
remote: Counting objects: 100% (92/92), done.
remote: Compressing objects: 100% (72/72), done.
remote: Total 92 (delta 18), reused 70 (delta 16), pack-reused 0 (from 0)
Receiving objects: 100% (92/92), 350.69 KiB | 3.31 MiB/s, done.
Resolving deltas: 100% (18/18), done.
# took ~1-2s, note the huge difference in data weight too
```

many plugin managers widely use `--depth=1` too (eg example from zgenom i've used before https://github.com/jandamm/zgenom/blob/ebb37d1459e793af4a45fff8491286da37f7612d/functions/zgenom-clone#L80-L82)